### PR TITLE
Viveport Library: Fixed failure to parse malformed installed_apps.json

### DIFF
--- a/source/ViveportLibrary.Tests/AppDataReaderTests.cs
+++ b/source/ViveportLibrary.Tests/AppDataReaderTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Linq;
+using Xunit;
+
+namespace ViveportLibrary.Tests
+{
+    public class AppDataReaderTests
+    {
+        [Fact]
+        public void GetInstalledApps_ReturnsInstalledApps()
+        {
+            var appDataReader = new AppDataReader("installed_apps.json");
+
+            var installedApps = appDataReader.GetInstalledApps();
+
+            Assert.Equal(2, installedApps.Count());
+        }
+
+        [Fact]
+        public void GetInstalledApps_IgnoresMalformedEntries_WhenMalformedEntriesExist()
+        {
+            var appDataReader = new AppDataReader("installed_apps_malformed.json");
+
+            var installedApps = appDataReader.GetInstalledApps();
+
+            Assert.Equal(2, installedApps.Count());
+            Assert.DoesNotContain(installedApps, x => x.Title == "Malformed Game");
+        }
+
+        [Fact]
+        public void GetInstalledApps_ReturnsNull_WhenNoFileExists()
+        {
+            var appDataReader = new AppDataReader("non_existing_file.json");
+
+            var installedApps = appDataReader.GetInstalledApps();
+
+            Assert.Null(installedApps);
+        }
+
+        [Fact]
+        public void GetInstalledApps_ReturnsNull_WhenFileIsEmpty()
+        {
+            var appDataReader = new AppDataReader("empty.json");
+
+            var installedApps = appDataReader.GetInstalledApps();
+
+            Assert.Null(installedApps);
+        }
+    }
+}

--- a/source/ViveportLibrary.Tests/ViveportLibrary.Tests.csproj
+++ b/source/ViveportLibrary.Tests/ViveportLibrary.Tests.csproj
@@ -60,10 +60,20 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AppDataReaderTests.cs" />
     <Compile Include="ViveportLibraryTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="empty.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="installed_apps_malformed.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="installed_apps.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/source/ViveportLibrary.Tests/installed_apps.json
+++ b/source/ViveportLibrary.Tests/installed_apps.json
@@ -1,0 +1,16 @@
+[
+  {
+    "appId": "ec53df3b-a2d6-41c6-a0a7-28e80934deee",
+    "title": "Sansar",
+    "imageUri": "https://assets-global.viveport.com/vr_developer_published_assets/app/ec53df3b-a2d6-41c6-a0a7-28e80934deee/image/thumbnail_small_v1593751558.png",
+    "path": "H:\\Viveport\\ViveApps\\ec53df",
+    "uri": "vive://runapp/ec53df3b-a2d6-41c6-a0a7-28e80934deee"
+  },
+  {
+    "appId": "4f5f140a-0928-4fcb-8023-93dc212eac17",
+    "title": "VIVEPORT Video",
+    "imageUri": "https://assets-global.viveport.com/vr_developer_published_assets/app/4f5f140a-0928-4fcb-8023-93dc212eac17/image/thumbnail_small_v1564383440.jpg",
+    "path": "H:\\Viveport\\ViveApps\\4f5f14",
+    "uri": "vive://runapp/4f5f140a-0928-4fcb-8023-93dc212eac17"
+  }
+]

--- a/source/ViveportLibrary.Tests/installed_apps_malformed.json
+++ b/source/ViveportLibrary.Tests/installed_apps_malformed.json
@@ -1,0 +1,23 @@
+[
+  {
+    "appId": "ec53df3b-a2d6-41c6-a0a7-28e80934deee",
+    "title": "Sansar",
+    "imageUri": "https://assets-global.viveport.com/vr_developer_published_assets/app/ec53df3b-a2d6-41c6-a0a7-28e80934deee/image/thumbnail_small_v1593751558.png",
+    "path": "H:\\Viveport\\ViveApps\\ec53df",
+    "uri": "vive://runapp/ec53df3b-a2d6-41c6-a0a7-28e80934deee"
+  },
+  {
+    "appId": "4f5f140a-0928-4fcb-8023-93dc212eac17",
+    "title": "VIVEPORT Video",
+    "imageUri": "https://assets-global.viveport.com/vr_developer_published_assets/app/4f5f140a-0928-4fcb-8023-93dc212eac17/image/thumbnail_small_v1564383440.jpg",
+    "path": "H:\\Viveport\\ViveApps\\4f5f14",
+    "uri": "vive://runapp/4f5f140a-0928-4fcb-8023-93dc212eac17"
+  },
+  {
+    "appId": null,
+    "title": "Malformed Game",
+    "imageUri": null,
+    "path": "H:\\Viveport\\ViveApps\\ec53df3b-a2d6-41c6-a0a7-28e80934deee\\1522443564",
+    "uri": "vive://runapp/ec53df3b-a2d6-41c6-a0a7-28e80934deee"
+  }
+]

--- a/source/ViveportLibrary/AppDataReader.cs
+++ b/source/ViveportLibrary/AppDataReader.cs
@@ -4,14 +4,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ViveportLibrary
 {
     public interface IAppDataReader
     {
         IEnumerable<InstalledAppData> GetInstalledApps();
+
         IEnumerable<LicensedAppData> GetLicensedApps();
     }
 
@@ -39,7 +38,8 @@ namespace ViveportLibrary
             }
 
             var fileContents = File.ReadAllText(AppStatePath);
-            var apps = JsonConvert.DeserializeObject<InstalledAppData[]>(fileContents);
+            var apps = JsonConvert.DeserializeObject<InstalledAppData[]>(fileContents)
+                ?.Where(x => x.AppId != null).ToArray();
 
             return apps;
         }
@@ -72,12 +72,16 @@ namespace ViveportLibrary
     {
         [JsonProperty("appId")]
         public string AppId;
+
         [JsonProperty("title")]
         public string Title;
+
         [JsonProperty("imageUri")]
         public string ImageUri;
+
         [JsonProperty("path")]
         public string Path;
+
         [JsonProperty("uri")]
         public string StartupUri;
     }


### PR DESCRIPTION
### Issue
Somehow my Viveport `installed_apps.json` file has a malformed game entry:
```
[
  {
    "appId": "ec53df3b-a2d6-41c6-a0a7-28e80934deee",
    "title": "Sansar",
    "imageUri": "https://assets-global.viveport.com/vr_developer_published_assets/app/ec53df3b-a2d6-41c6-a0a7-28e80934deee/image/thumbnail_small_v1593751558.png",
    "path": "H:\\Viveport\\ViveApps\\ec53df",
    "uri": "vive://runapp/ec53df3b-a2d6-41c6-a0a7-28e80934deee"
  },
  {
    "appId": "4f5f140a-0928-4fcb-8023-93dc212eac17",
    "title": "VIVEPORT Video",
    "imageUri": "https://assets-global.viveport.com/vr_developer_published_assets/app/4f5f140a-0928-4fcb-8023-93dc212eac17/image/thumbnail_small_v1564383440.jpg",
    "path": "H:\\Viveport\\ViveApps\\4f5f14",
    "uri": "vive://runapp/4f5f140a-0928-4fcb-8023-93dc212eac17"
  },
  {
    "appId": "bbbc73fc-b018-42ce-a049-439ab378dbc6",
    "title": "Tilt Brush",
    "imageUri": "https://assets-global.viveport.com/vr_developer_published_assets/app/bbbc73fc-b018-42ce-a049-439ab378dbc6/image/thumbnail_small_v1506399232.jpg",
    "path": "H:\\Viveport\\ViveApps\\bbbc73",
    "uri": "vive://runapp/bbbc73fc-b018-42ce-a049-439ab378dbc6"
  },
  {
    "appId": "65d81211-14f6-4eb1-9a92-5346fe6bf572",
    "title": "VIVEPORT VR",
    "imageUri": "https://assets-global.viveport.com/vr_developer_published_assets/app/65d81211-14f6-4eb1-9a92-5346fe6bf572/image/thumbnail_small_v1558927037.jpg",
    "path": "H:\\Viveport\\ViveApps\\65d812",
    "uri": "vive://runapp/65d81211-14f6-4eb1-9a92-5346fe6bf572"
  },
  {
    "appId": null,
    "title": "Sansar",
    "imageUri": null,
    "path": "H:\\Viveport\\ViveApps\\ec53df3b-a2d6-41c6-a0a7-28e80934deee\\1522443564",
    "uri": "vive://runapp/ec53df3b-a2d6-41c6-a0a7-28e80934deee"
  }
]
```

As you can see, last item has `appId == null`.

This would result in an error `Value cannot be null. Parameter name: key` when casting to a dictionary.

![image](https://user-images.githubusercontent.com/17652035/203864063-9c8059ac-3838-4fbd-8e37-d05a9b1e47ca.png)

### Solution
Added filtering out malformed app entries when reading `installed_apps.json`.
Added tests to verify.

### Remarks
I'm not sure why, but projects do not build, since it's trying to load Newtonsoft.Json 13.0.0.0, while the projects reference 10.0.3. 

I could also just fixed my `installed_apps.json`, but maybe it's better to have a more resilient plugin. Not sure how that file got malformed on my machine.