### PR TITLE
GiantBomb Metadata: New setting to return only 1 franchise in metadata

### DIFF
--- a/source/GiantBombMetadata/GiantBombMetadataProvider.cs
+++ b/source/GiantBombMetadata/GiantBombMetadataProvider.cs
@@ -271,7 +271,19 @@ namespace GiantBombMetadata
 
         public override IEnumerable<MetadataProperty> GetSeries(GetMetadataFieldArgs args)
         {
-            return GetGameDetails().Franchises?.Select(f => new MetadataNameProperty(f.Name));
+            if (!plugin.Settings.Settings.GetSingleSeries || GetGameDetails() == null || GetGameDetails().Franchises.Length < 1)
+            {
+                return GetGameDetails().Franchises?.Select(f => new MetadataNameProperty(f.Name));
+            }
+
+            List<MetadataNameProperty> list = new List<MetadataNameProperty>();
+
+            MetadataNameProperty first = new MetadataNameProperty(GetGameDetails().Franchises.FirstOrDefault().Name);
+            list.Add(first);
+
+            IEnumerable<MetadataProperty> iList = list;
+
+            return iList;
         }
 
         public override IEnumerable<MetadataProperty> GetAgeRatings(GetMetadataFieldArgs args)

--- a/source/GiantBombMetadata/GiantBombMetadataProvider.cs
+++ b/source/GiantBombMetadata/GiantBombMetadataProvider.cs
@@ -276,14 +276,12 @@ namespace GiantBombMetadata
                 return GetGameDetails().Franchises?.Select(f => new MetadataNameProperty(f.Name));
             }
 
-            List<MetadataNameProperty> list = new List<MetadataNameProperty>();
+            List<MetadataProperty> list = new List<MetadataProperty>();
 
-            MetadataNameProperty first = new MetadataNameProperty(GetGameDetails().Franchises.FirstOrDefault().Name);
+            MetadataNameProperty first = new MetadataNameProperty(GetGameDetails().Franchises.First().Name);
             list.Add(first);
 
-            IEnumerable<MetadataProperty> iList = list;
-
-            return iList;
+            return list;
         }
 
         public override IEnumerable<MetadataProperty> GetAgeRatings(GetMetadataFieldArgs args)

--- a/source/GiantBombMetadata/GiantBombMetadataSettings.cs
+++ b/source/GiantBombMetadata/GiantBombMetadataSettings.cs
@@ -18,6 +18,7 @@ namespace GiantBombMetadata
         public GiantBombPropertyImportSetting Objects { get; set; } = new GiantBombPropertyImportSetting { Prefix = "Object: ", ImportTarget = PropertyImportTarget.Ignore };
         public GiantBombPropertyImportSetting Themes { get; set; } = new GiantBombPropertyImportSetting { Prefix = "", ImportTarget = PropertyImportTarget.Tags };
         public GiantBombPropertyImportSetting People { get; set; } = new GiantBombPropertyImportSetting { Prefix = "Person: ", ImportTarget = PropertyImportTarget.Ignore };
+        public bool GetSingleSeries { get; set; } = false;
         public bool ShowTopPanelButton { get; set; } = true;
     }
 

--- a/source/GiantBombMetadata/GiantBombMetadataSettingsView.xaml
+++ b/source/GiantBombMetadata/GiantBombMetadataSettingsView.xaml
@@ -16,6 +16,7 @@
                 <RowDefinition Height="auto"/>
                 <RowDefinition Height="15"/>
                 <RowDefinition Height="auto"/>
+                <RowDefinition Height="auto"/>
             </Grid.RowDefinitions>
             <TextBlock Text="API Key:" Grid.Column="0" Grid.Row="0" VerticalAlignment="Center"/>
             <TextBox Name="ApiKeyTextbox" Text="{Binding Settings.ApiKey}" Margin="10,0,0,0" Grid.Column="1" Grid.Row="0" VerticalAlignment="Center"/>
@@ -23,6 +24,7 @@
                         Command="{Binding GetApiKeyCommand}" Margin="10,0,0,0"/>
 
             <CheckBox Grid.Row="2" Grid.Column="1" Margin="10,0" Content="Show top panel button to add metadata to multiple games" IsChecked="{Binding Settings.ShowTopPanelButton}"/>
+            <CheckBox Grid.Row="3" Grid.Column="1" Margin="10,10,10,0" Content="Get only the first series from Metadata search" IsChecked="{Binding Settings.GetSingleSeries}"/>
         </Grid>
         <Grid Margin="0,20">
             <Grid.Resources>


### PR DESCRIPTION
Allowing the user to only get the first Franchise when searching on Metadata which looks to always be the parent franchise i.e. Final Fantasy 7 Remake has Final Fantasy and Compilation of Final Fantasy 7. One Piece Pirate Warriors 4 has One Piece, One Piece: Pirate Warriors and Musou. This change aims to only return what I call the overall series and avoid having multiple franchises created when auto importing new games

Was inspired to make this change as I want series to be included in my auto imports but don't want unnessary series only what overall property it comes from.