### PR TITLE
MobyGames: Add 360 api request per hour constraint

### DIFF
--- a/source/MobyGamesMetadata/Api/MobyGamesApiClient.cs
+++ b/source/MobyGamesMetadata/Api/MobyGamesApiClient.cs
@@ -38,7 +38,11 @@ namespace MobyGamesMetadata.Api
                 if (apiKey != value && !string.IsNullOrEmpty(value))
                 {
                     restClient?.Dispose();
-                    var limiter = TimeLimiter.GetFromMaxCountByInterval(1, TimeSpan.FromSeconds(1)).AsDelegatingHandler();
+                    // MobyGames API limits: 360 per hour and requests should be made no more frequently than one per second.
+                    var constraint1 = new CountByIntervalAwaitableConstraint(360, TimeSpan.FromHours(1));
+                    var constraint2 = new CountByIntervalAwaitableConstraint(1, TimeSpan.FromSeconds(1));
+
+                    var limiter = TimeLimiter.Compose(constraint1, constraint2).AsDelegatingHandler();
                     restClient = new RestClient(new HttpClient(limiter), new RestClientOptions(BaseUrl), disposeHttpClient: true)
                         .AddDefaultQueryParameter("api_key", value);
                 }


### PR DESCRIPTION
MobyGames indicates the following limits:

[Right now, API requests are limited to 360 per hour (one every ten seconds). In addition, requests should be made no more frequently than one per second. ](https://www.mobygames.com/info/api/#limits)

The plugin is missing the first constraint, which is probably the cause for getting 429 responses for too many requests on #41

As another change I think it would be good if the limiter was not built inside the setter since it could cause issues like recreating the limiter if the API key is changed and "forget" the previous requests count, which could result in surpassing the number of permitted API requests.